### PR TITLE
JDP190901-28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springframework.boot:spring-boot-starter-web')
+    implementation('org.projectlombok:lombok:1.18.10')
     runtimeOnly('com.h2database:h2')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }


### PR DESCRIPTION
**Lombok - dodanie biblioteki**

Do pliku gradle.build został dodany wpis importujący bibliotekę Lombok.

Przypominam, że do poprawnego działania Lomboka potrzebne jest
zainstalowanie w IntelliJ pluginu Lombok oraz włączenie procesowania
adnotacji w projekcie w ustawieniach:
Build, Execution, Deployment > Compiler > Annotation Processors >
Enable annotation processing