### PR TITLE
JDP190901-29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springframework.boot:spring-boot-starter-web')
+    implementation('mysql:mysql-connector-java:8.0.17')
     runtimeOnly('com.h2database:h2')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+# DATABASE CONFIGURATION
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database=mysql
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+spring.datasource.url=jdbc:mysql://localhost:3306/ecommercee?serverTimezone=Europe/Warsaw&useSSL=false
+spring.datasource.username=ecommercee_app
+spring.datasource.password=ecommercee_password


### PR DESCRIPTION
**Konfiguracja bazy danych**

Do pliku gradle.build dodałem wpis importujący sterownik do bazy
danych MySQL.
W pliku application.properties umieściłem konfigurację bazy danych.

Teraz każdy musi na swoim lokalnym serwerze MySQL utworzyć schemat
bazy danych i użytkownika zgodnych z konfiguracją.